### PR TITLE
Merge develop: support relative and absolute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Documentation repository
 
-If you're browsing this on Github, please use this link to the [wiki](../../wiki).
+If you're browsing this on Github from `master/HEAD`, please use this link to the [wiki](../../wiki).
 
-If you're browsing this on a local clone of the repository, please use this link to the [wiki](https://github.com/morancj/documentation-0/wiki).
+If you're browsing this on a local clone of the repository, or from the repo `blob` history, please use this link instead: [wiki](https://github.com/morancj/documentation-0/wiki).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Documentation repository
 
-Please see the [wiki](https://github.com/morancj/documentation-0/wiki).
+Please see the [wiki](../../wiki/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Documentation repository
 
-Please see the [wiki](../../wiki/).
+If you're browsing this on Github, please use this link to the [wiki](../../wiki).
+
+If you're browsing this on a local clone of the repository, please use this link to the [wiki](https://github.com/morancj/documentation-0/wiki).
 


### PR DESCRIPTION
Relative links won't work from a local `git clone`, nor on GitHub commit history.